### PR TITLE
16 set up sql insert process for data importing

### DIFF
--- a/ImplementationToolbox/genericDataImport.h
+++ b/ImplementationToolbox/genericDataImport.h
@@ -68,7 +68,7 @@ std::string displayDataFiles(std::string dir);
 
 std::string displayTableNames(Sql& sql);
 
-void displayMappingTable(AppLog&, DisplaySettings& ds, std::vector<std::string>& s_columns, std::vector<std::string>& d_columns, std::vector<std::string>& b_columns, std::vector<std::string>& rows, std::vector<int>& b_columns_index, std::vector<int>&, std::vector<int>&, int&, bool* nulls);
+void displayMappingTable(AppLog&, DisplaySettings& ds, std::vector<std::string>& s_columns, std::vector<std::string>& d_columns, std::vector<std::string>& b_columns, std::vector<std::string>& rows, std::vector<int>& b_columns_index, std::vector<int>&, std::vector<int>&, int&, bool* nulls, bool* duplicates);
 
 std::vector<std::string> buildInsertQuery(std::string table_name, std::vector<int>& d_columns_index, std::vector<std::string>& d_columns, std::vector<std::string>& rows, std::vector<int>& rows_index, bool* nulls, AppLog& log);
 


### PR DESCRIPTION
Added functionality to performance inserts after checking for duplicates (if desired) users can select columns that can't accept duplicates on import, and it will automatically filter out rows BEFORE it generates the insert statement.

Added functionality to run all insert statements at once, or do them one at a time with a SQL button beside each insert.

Utilized multi-threading (only on bulk insert) so the program doesn't freeze up while attempting to perform the SQL insert.

Print out is generated at the bottom of the window to see which rows were successfully inserted into SQL.

Closes #16 
